### PR TITLE
Fix broken blog links

### DIFF
--- a/blog-saving-too-much.html
+++ b/blog-saving-too-much.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>When is Too Much Savings Too Much? – FIREStack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>When is Too Much Savings Too Much?</h1>
+    <p>by FIREStack | Coming Soon</p>
+  </header>
+
+  <article>
+    <h2>Balancing Saving and Living</h2>
+    <p>We're preparing content on finding the right balance between aggressive saving and enjoying life along the way.</p>
+
+    <footer>
+      <p>While we finish this piece, try the <a href="calculator.html">FIRE Calculator</a> or <a href="index.html">browse other posts</a>.</p>
+    </footer>
+  </article>
+</body>
+</html>

--- a/blog-where-to-start.html
+++ b/blog-where-to-start.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Where to Start Your FIRE Journey – FIREStack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Where to Start Your FIRE Journey</h1>
+    <p>by FIREStack | Coming Soon</p>
+  </header>
+
+  <article>
+    <h2>Getting Started</h2>
+    <p>This article is under construction. Check back soon for tips on how to begin your path toward Financial Independence and Early Retirement.</p>
+
+    <footer>
+      <p>In the meantime, explore the <a href="calculator.html">FIRE Calculator</a> or <a href="index.html">return home</a>.</p>
+    </footer>
+  </article>
+</body>
+</html>

--- a/calculator.html
+++ b/calculator.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FIRE Calculator – FIREStack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>FIRE Calculator</h1>
+    <p>Coming Soon</p>
+  </header>
+
+  <section>
+    <p>We're building a calculator to help you estimate your path to financial independence. Check back soon!</p>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add placeholder pages for missing blog articles
- add placeholder calculator page for referenced links

## Testing
- `npm test` *(fails: ENOENT cannot read package.json)*
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68606533a82c8324986b3d568a58b82a